### PR TITLE
Update the-difference-between-sli-slo-and-sla.md

### DIFF
--- a/the-difference-between-sli-slo-and-sla.md
+++ b/the-difference-between-sli-slo-and-sla.md
@@ -16,7 +16,7 @@ The SLA, SLO, and SLI are related concepts though they're different concepts.
 
 So here is the relationship. The service provider needs to collect metrics based on SLI, define thresholds of metrics based on SLO, and monitor the thresholds of metrics so that it won't break SLA. In practical, the SLIs are the metrics in the monitoring system; the SLOs are alerting rules, and the SLAs are the numbers of the monitoring metrics applying to the SLOs.
 
-Usually the SLO and the SLA are similar while the SLO is looser than SLA. The SLOs are generally used for internal only, and the SLAs are for external. If a service availability violates the SLO, operations need to react quickly to avoid it breaking SLA, otherwise, the company might need to refund some money to customers.
+Usually the SLO and the SLA are similar while the SLO is tighter than the SLA. The SLOs are generally used for internal only, and the SLAs are for external. If a service availability violates the SLO, operations need to react quickly to avoid it breaking SLA, otherwise, the company might need to refund some money to customers.
 
 The SLA, SLO, and SLI are based on such assumption that is the service will not be available 100%. Instead, we guarantee that the system will be available greater than a certain number, for example, 99.5%.
 


### PR DESCRIPTION
This is a great explanation of the differences between SLOs, SLIs and SLAs. Suggesting a minor word change to clarify the difference between SLOs and SLAs with respect to which is more restrictive than the other. Generally, SLOs are harder for an organization to meet than an SLA (there is slack between the SLO and the SLA so that when an alert goes off based on an SLO, there is time to fix it before the organization violates the SLA). I feel the word tighter here would communicate this more clearly than the word looser. Thanks for this writeup and for putting it on the internet!